### PR TITLE
Update Dokka to v2.0.0-Beta and fix configuration

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -146,8 +146,8 @@ jobs:
         run: make android-lib-arm-v8
 
       - name: Build API documentation
-        run: ./gradlew dokkaHtml
-      
+        run: ./gradlew dokkaGenerate
+
       - name: Build Examples documentation
         run: make mkdocs-build
 

--- a/.github/workflows/gh-pages-android-api.yml
+++ b/.github/workflows/gh-pages-android-api.yml
@@ -23,7 +23,7 @@ jobs:
           java-version: "17"
 
       - name: Generate documentation
-        run: ./gradlew dokkaHtml
+        run: ./gradlew dokkaGenerate
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@v4.6.9
@@ -31,4 +31,3 @@ jobs:
           branch: gh-pages
           folder: platform/android/MapLibreAndroid/build/dokka/html
           target-folder: android/api/
-      

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /platform/android/armeabi-v7a
 /platform/android/MapLibreAndroid/.cxx
 /platform/android/MapLibreAndroid/build
+/platform/android/MapLibrePlugin/build
 /platform/android/MapLibreAndroidTestApp/.cxx
 /platform/android/MapLibreAndroidTestApp/build
 /platform/android/buildSrc/build

--- a/platform/android/MapLibreAndroid/build.gradle.kts
+++ b/platform/android/MapLibreAndroid/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.jetbrains.dokka.gradle.DokkaTask
-
 plugins {
     alias(libs.plugins.kotlinter)
     alias(libs.plugins.dokka)
@@ -38,11 +36,11 @@ dependencies {
     androidTestImplementation(libs.testRules)
 }
 
-tasks.withType<DokkaTask> {
+dokka {
     moduleName.set("MapLibre Native Android")
 
     dokkaSourceSets {
-        named("main") {
+        main {
             includes.from("Module.md")
         }
     }

--- a/platform/android/gradle.properties
+++ b/platform/android/gradle.properties
@@ -5,3 +5,5 @@ org.gradle.jvmargs=-Xmx4096M
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false
 android.injected.androidTest.leaveApksInstalledAfterRun=true
+org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
+org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true

--- a/platform/android/gradle/libs.versions.toml
+++ b/platform/android/gradle/libs.versions.toml
@@ -82,14 +82,14 @@ androidxTestExtJUnit = { group = "androidx.test.ext", name = "junit", version = 
 androidxTestCoreKtx = { group = "androidx.test", name = "core-ktx", version = "1.6.1" }
 kotlinxSerializationJson = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version = "1.7.2" }
 
-androidGradlePlugin = { group = "com.android.tools.build", name = "gradle", version.ref = "androidGradlePlugin"}
+androidGradlePlugin = { group = "com.android.tools.build", name = "gradle", version.ref = "androidGradlePlugin" }
 
 
 [plugins]
 nexusPublishPlugin = { id = "io.github.gradle-nexus.publish-plugin", version = "2.0.0" }
 kotlinter = { id = "org.jmailen.kotlinter", version = "4.4.1" }
 kotlinAndroid = { id = "org.jetbrains.kotlin.android", version = "2.0.20" }
-dokka = { id = "org.jetbrains.dokka", version = "1.9.20" }
+dokka = { id = "org.jetbrains.dokka", version = "2.0.0-Beta" }
 kotlinPluginSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version = "2.0.20" }
 android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }
 android-library = { id = "com.android.library", version.ref = "androidGradlePlugin" }

--- a/platform/android/settings.gradle.kts
+++ b/platform/android/settings.gradle.kts
@@ -25,7 +25,7 @@ plugins {
 
 include(":MapLibreAndroid", ":MapLibreAndroidTestApp", ":MapLibreAndroidLint")
 
-rootProject.name = "MapLibre Native for Android"
+rootProject.name = "MapLibreNativeForAndroid"
 
 val renderTestProjectDir = file("$rootDir/../../render-test/android")
 includeBuild(renderTestProjectDir) {


### PR DESCRIPTION
Updates Dokka documentation generator to version 2.0.0-Beta and adjusts related configuration

- Upgrades Dokka from 1.9.20 to 2.0.0-Beta
- Removes spaces from root project name, because the spaces were causing errors
- Extra: updates .gitignore to include MapLibrePlugin build directory as this seems to have been missed in a previous commit
